### PR TITLE
Adapt to Coq 8.17

### DIFF
--- a/FOLL/LL/Examples/LJLL.v
+++ b/FOLL/LL/Examples/LJLL.v
@@ -238,8 +238,8 @@ Proof with unfold Theory in *;solveF;simplifyG.
   eapply tri_ex with (t:= (FC1 pr (Cte (PL.atom 2)))).
   simpl.
 
-  eapply tri_tensor with (N:= [(A1 lf (FC2 cj (FC1 pr (Cte (PL.atom 1))) (FC1 pr (Cte (PL.atom 2))))) ⁺])           
-                         (M:= [(A1 rg (FC2 cj (FC1 pr (Cte (PL.atom 1))) (FC1 pr (Cte (PL.atom 2))))) ⁺]) ...                              
+  eapply tri_tensor with (N:= [(A1 lf (FC2 cj (FC1 pr (Cte (PL.atom 1))) (FC1 pr (Cte (PL.atom 2))))) ⁺])
+                         (M:= [(A1 rg (FC2 cj (FC1 pr (Cte (PL.atom 1))) (FC1 pr (Cte (PL.atom 2))))) ⁺]); [ solveF | | ].
   apply Init1 ...
   apply tri_rel ...
   NegPhase.
@@ -249,8 +249,8 @@ Proof with unfold Theory in *;solveF;simplifyG.
   eapply tri_ex with (t:= FC1 pr (Cte (PL.atom 2))).
   eapply tri_tensor with
       (N:= [(A1 rg (FC2 cj (FC1 pr (Cte (PL.atom 1))) (FC1 pr (Cte (PL.atom 2))))) ⁺])
-      (M:=[Atom (A1 lf (FC1 pr (Cte (PL.atom 1)))) ; Atom (A1 lf (FC1 pr (Cte (PL.atom 2)) ))]);eauto ...
-  eapply Init1 ...
+      (M:=[Atom (A1 lf (FC1 pr (Cte (PL.atom 1)))) ; Atom (A1 lf (FC1 pr (Cte (PL.atom 2)) ))]); [ solveF | | ].
+  apply Init1 ...
   eapply tri_rel ...
   eapply tri_with ; eapply tri_store ...
 
@@ -673,7 +673,7 @@ Proof with solveF.
     eapply tri_tensor with (N:= [A1 rg (FC1 pr (Cte (PL.atom a))) ⁺ ; (A1 lf (FC1 pr (Cte (PL.atom a)))) ⁺])
                            (M:= encodeList L');eauto.
     eapply tri_tensor with (N:=[(A1 rg (FC1 pr (Cte (PL.atom a)))) ⁺])
-                           (M:= [(A1 lf (FC1 pr (Cte (PL.atom a)))) ⁺]) ...
+                           (M:= [(A1 lf (FC1 pr (Cte (PL.atom a)))) ⁺]); [ solveF | | ] .
     apply Init1 ...
     apply Init1 ...
     apply tri_rel...
@@ -681,9 +681,8 @@ Proof with solveF.
     apply multisetEncode in H. simpl in H.
     rewrite H. autounfold. simpl.
     eapply tri_dec2 with (F:= BLEFT);eauto.
-    eapply tri_tensor with (N:= [(A1 lf (Cte PL.bot)) ⁺] ) (M:=  (A1 rg (encodeTerm F)) ⁺ :: encodeList L') ...
+    eapply tri_tensor with (N:= [(A1 lf (Cte PL.bot)) ⁺] ) (M:=  (A1 rg (encodeTerm F)) ⁺ :: encodeList L'); [ | apply Init1 | ]...
 
-    apply Init1 ...
   + (* Inductive Cases *) 
     inversion HD;subst;autounfold in *;simpl;autounfold;simpl;simplifyG.
     ++ (* Conj R *) 
@@ -1194,9 +1193,9 @@ Proof with solveF.
   apply AtomsTheoryFalse in H10.
   contradiction.
   
-  (* H3 is inconsisten *)
+  (* H3 is inconsistent *)
   inversion H3 ...
-  simpl in H6. intuition.
+  discriminate H6.
 Qed.
 
 
@@ -1251,7 +1250,7 @@ Proof with solveF.
   apply AtomsTheoryFalse in H7. contradiction.
   (* cannot be a release *)
   inversion H3;subst.
-  unfold lf in H7. simpl in H7. intuition.
+  discriminate H4.
 Qed.
 
 
@@ -1336,13 +1335,13 @@ Proof with solveF.
   apply AtomsTheoryFalse in H7. contradiction.
   (* cannot be a release *)
   inversion H2;subst.
-  unfold lf in H4. simpl in H4. intuition.
+  discriminate H4.
   
   (* cannot be from B *)
   apply AtomsTheoryFalse in H11. contradiction.
   (* cannot be a release *)
   inversion H2;subst.
-  unfold lf in H5. simpl in H5. intuition.
+  discriminate H5.
 Qed.
 
 
@@ -1397,7 +1396,7 @@ Proof with solveF.
   apply AtomsTheoryFalse in H7. contradiction.
   (* cannot be a release *)
   inversion H2;subst.
-  unfold lf in H3. simpl in H3. intuition.
+  discriminate H3.
 Qed.
 
 
@@ -1439,7 +1438,8 @@ Proof with solveF.
   (* cannot be from the theory *)
   apply AtomsTheoryFalse in H7 ; contradiction.
   (* cannot be a release *)
-  inversion H2... intuition.
+  inversion H2...
+  discriminate H3.
 Qed.
 
 Lemma InvDRIGHT2 :forall F L n,  n |-F- Theory; (encodeFR F) :: encodeList L; DW DRIGHT2 -> exists   G1 G2 n1, n =  (S (S (S ( S (S n1)))))  /\ F = PL.disj G1 G2 /\ n1 |-F- Theory; encodeFR G2 :: encodeList L ; UP [].
@@ -1479,7 +1479,8 @@ Proof with solveF.
   (* cannot be from the theory *)
   apply AtomsTheoryFalse in H7 ; contradiction.
   (* cannot be a release *)
-  inversion H2... intuition.
+  inversion H2.
+  discriminate H3.
 Qed.
 
 Lemma InvIRight :forall F L n,  n |-F- Theory; (encodeFR F) :: encodeList L; DW IRIGHT -> exists   G1 G2 n1, n =  (S (S (S ( S (S (S (S n1)))))))  /\ F = PL.impl G1 G2 /\ n1 |-F- Theory; encodeFR G2 :: encodeFL G1 :: encodeList L ; UP [].
@@ -1519,7 +1520,8 @@ Proof with solveF.
   (* cannot be from the theory *)
   apply AtomsTheoryFalse in H7. contradiction.
   (* Cabbot be  release *)
-  inversion H2;subst ... intuition.
+  inversion H2;subst.
+  discriminate H3.
 Qed.
 
 Theorem Completeness : forall L F, ( encodeSequent L F ) -> exists n, L |-P- n ; F.

--- a/FOLL/LL/FLLMetaTheory.v
+++ b/FOLL/LL/FLLMetaTheory.v
@@ -380,10 +380,10 @@ Module FLLMetaTheory (DT : Eqset_dec_pol).
         apply IH  with (L:= F :: L) (m:= Exp_weight F + L_weight L) in Hp1;try(lia); subst;autounfold;simpl;try(lia); auto.
         apply IH  with (L:= G :: L) (m:= Exp_weight G + L_weight L) in Hp2;try(lia); subst;autounfold;simpl;try(lia); auto.
       ++  (* quest *)
-        assert(Hp: forall x,  |-F- B ++ [F]; M; UP (L ++ [Subst FX x] ++ L')) .
-        intro; generalize (H x); intro Hp'; inversion Hp'; subst;LexpContr;intuition ... auto.
-        apply IH  with (m:= L_weight  L) in Hp;auto. 
-        subst;inversion Hw';lia .
+        assert(Hp: forall x,  |-F- B ++ [F]; M; UP (L ++ [Subst FX x] ++ L')).
+        intro; generalize (H x); intro Hp'; inversion Hp'; subst;LexpContr... auto.
+        apply IH  with (m:= L_weight  L) in Hp;auto.
+        subst;inversion Hw';lia.
       ++ (* forall *)
         subst.
         assert(Hp: forall x x', |-F- B; M; UP ((Subst FX0 x') :: L ++ [Subst FX x] ++ L')).

--- a/FOLL/LL/SequentCalculiBasicTheory.v
+++ b/FOLL/LL/SequentCalculiBasicTheory.v
@@ -915,15 +915,11 @@ easily conclude the goal [G].
       eexists.
       rewrite app_nil_r.
       eauto.
-    + inversion H;subst; try(
-                             inversion H0;
-                             simpl in H1;
-                             intuition).
-      apply H3 in H7.
+    + inversion H; subst; inversion H0; try discriminate H1.
+      apply (IHN H2) in H7.
       destruct H7.
       eexists.
-      assert( (M ++ [a]) ++ N =mul=  M ++ a :: N) by solve_permutation.
-      rewrite <- H5.
+      assert( (M ++ [a]) ++ N =mul=  M ++ a :: N) as <- by solve_permutation.
       eauto.
   Qed.
 

--- a/FOLL/LL/Syntax.v
+++ b/FOLL/LL/Syntax.v
@@ -161,8 +161,7 @@ Module Syntax_LL (DT : Eqset_dec_pol).
   (** We assume equality on formulas to be decidable *)
   Axiom FEqDec : forall (F G: Lexp ),  {F = G} + {F <> G}.
   Lemma not_eqLExp_sym : forall x y: Lexp,  x <> y -> y <> x.
-  Proof. intuition.
-  Qed.
+  Proof. auto. Qed.
 
   (* Case analysis on a formula *)
   Ltac caseLexp F :=
@@ -550,64 +549,64 @@ Module Syntax_LL (DT : Eqset_dec_pol).
 
     (* Simplification of terms *)
     Lemma EqAtom : forall A , (fun T : Type => atom (A T)) = Atom (A) .
-    Proof. intuition.  Qed.
+    Proof. auto. Qed.
 
     Lemma EqPerp : forall A , (fun T : Type => perp (A T)) = Perp (A) .
-    Proof. intuition.  Qed.
+    Proof. auto. Qed.
 
     Lemma EqTop :  (fun T : Type => top) = Top .
-    Proof. intuition.  Qed.
+    Proof. auto. Qed.
 
     Lemma EqBot :  (fun T : Type => bot) = Bot.
-    Proof. intuition.  Qed.
+    Proof. auto. Qed.
 
     Lemma EqOne :  (fun T : Type => one) = One.
-    Proof. intuition.  Qed.
+    Proof. auto. Qed.
 
     Lemma EqZero :  (fun T : Type => zero) = Zero .
-    Proof. intuition.  Qed.
+    Proof. auto. Qed.
 
     Lemma EqTensor :  forall F G, (fun T : Type => tensor (F T)  (G T)) = Tensor F G.
-    Proof. intuition.  Qed.
+    Proof. auto. Qed.
 
     Lemma EqPar :  forall F G, (fun T : Type => par (F T)  (G T)) = Par F G.
-    Proof. intuition.  Qed.
+    Proof. auto. Qed.
 
     Lemma EqPlus :  forall F G, (fun T : Type => oplus (F T)  (G T)) = Plus F G.
-    Proof. intuition.  Qed.
+    Proof. auto. Qed.
 
     Lemma EqWith :  forall F G, (fun T : Type => witH (F T)  (G T)) = With F G.
-    Proof. intuition.  Qed.
+    Proof. auto. Qed.
 
     Lemma EqBang :  forall F, (fun T : Type => bang (F T) ) = Bang F.
-    Proof. intuition.  Qed.
+    Proof. auto. Qed.
 
     Lemma EqQuest :  forall F, (fun T : Type => quest (F T) ) = Quest F.
-    Proof. intuition.  Qed.
+    Proof. auto. Qed.
 
     Lemma EqEx :  forall FX, (fun T : Type => ex (FX T) ) = Ex FX.
-    Proof. intuition. Qed.
+    Proof. auto. Qed.
 
     Lemma EqFx :  forall FX, (fun T : Type => fx (FX T) ) = Fx FX.
-    Proof. intuition. Qed.
+    Proof. auto. Qed.
 
     Lemma EqA0 : forall n , (fun T : Type => a0 n ) = A0 n.
-    Proof. intuition. Qed.
+    Proof. auto. Qed.
 
     Lemma EqA1 : forall n t , (fun T : Type => a1 n (t T)) = A1 n t.
-    Proof. intuition. Qed.
+    Proof. auto. Qed.
 
     Lemma EqA2 : forall n t t' , (fun T : Type => a2 n (t T) (t' T)) = A2 n t t'.
-    Proof. intuition. Qed.
+    Proof. auto. Qed.
 
     Lemma EqCte : forall t , (fun T : Type => cte t ) = Cte t.
-    Proof. intuition. Qed.
+    Proof. auto. Qed.
 
     Lemma EqFC1 : forall n t , (fun T : Type => fc1 n (t T) ) = FC1 n t.
-    Proof. intuition. Qed.
+    Proof. auto. Qed.
 
     Lemma EqFC2 : forall n t t' , (fun T : Type => fc2 n (t T) (t' T)) = FC2 n t t'.
-    Proof. intuition. Qed.
+    Proof. auto. Qed.
 
   End EqualityFormulas. 
 
@@ -1021,8 +1020,8 @@ Module Syntax_LL (DT : Eqset_dec_pol).
     Lemma Flatten_dual : forall T (F: lexp (term T)), flatten F = dual_LExp(flatten ( dual_LExp F)).
       intros.
       induction F;simpl;try(destruct a);try(reflexivity);
-        try(simpl;rewrite IHF1;rewrite IHF2; intuition);
-        try(simpl;rewrite IHF; intuition).
+        try(simpl;rewrite IHF1;rewrite IHF2; auto);
+        try(simpl;rewrite IHF; auto).
 
       assert(Hs : (fun x : T => flatten (f (var x))) =  (fun x : T => dual_LExp (flatten (dual_LExp (f (var x))))))
         by (extensionality x; generalize(H (var x));auto);rewrite Hs; reflexivity.
@@ -1208,7 +1207,7 @@ Module Syntax_LL (DT : Eqset_dec_pol).
       + intro HN.
         apply AsyncEqL in HN.
         rewrite H in HN.
-        intuition.
+        discriminate HN.
     Qed.
 
     Inductive posOrNegAtom : lexp unit -> Prop :=
@@ -1249,21 +1248,21 @@ Module Syntax_LL (DT : Eqset_dec_pol).
     Lemma ApropPosNegAtom : forall A: AProp, IsPositiveAtom (Atom A) \/ IsNegativeAtom(Atom A).
       intros.
       assert(HC : ClosedA A3) by apply ax_closedA.
-      inversion HC;remember(isPositive n); destruct b;intuition;[left | right |left | right];constructor;auto.
+      inversion HC;remember(isPositive n); destruct b;auto;[left | right |left | right];constructor;auto.
     Qed.
 
     Lemma ApropPosNegAtom' : forall A: AProp, IsPositiveAtom (Perp A) \/ IsNegativeAtom(Perp A).
       intros.
       assert(HC : ClosedA A3) by apply ax_closedA.
-      inversion HC;remember(isPositive n); destruct b;intuition; [right | left | right | left] ; constructor;auto.
+      inversion HC;remember(isPositive n); destruct b;auto; [right | left | right | left] ; constructor;auto.
     Qed.
 
     Lemma NotAsynchronousPosAtoms : forall F, ~ Asynchronous  F -> PosFormula F \/ IsPositiveAtom F \/ IsNegativeAtom F.
       intros.
-      caseLexp F;intuition;try (left;constructor);
+      caseLexp F;auto;try (left;constructor);
         [idtac | idtac | (contradict H;subst;auto) .. ].
-      generalize( ApropPosNegAtom  A3); intro HA3;destruct HA3;intuition.
-      generalize( ApropPosNegAtom'  A3); intro HA3;destruct HA3;intuition.
+      generalize( ApropPosNegAtom  A3); intro HA3;destruct HA3;auto.
+      generalize( ApropPosNegAtom'  A3); intro HA3;destruct HA3;auto.
     Qed.
 
     Lemma NegPosAtomContradiction: forall F, PosOrNegAtom F ->  IsPositiveAtom F -> False.
@@ -1272,13 +1271,13 @@ Module Syntax_LL (DT : Eqset_dec_pol).
         rewrite <- H2 in H;
         inversion H;
         rewrite <- H4  in H1;
-        intuition.
+        discriminate.
     Qed.
 
     Lemma  IsNegativePosOrNegAtom : forall F,  IsNegativeAtom F -> PosOrNegAtom F.
     Proof.
       intros.
-      inversion H;constructor;auto. 
+      inversion H;constructor;auto.
     Qed.
 
     Lemma PosOrNegAtomAsync : forall F, PosOrNegAtom F ->  AsynchronousF F = false.
@@ -1529,7 +1528,7 @@ Module Syntax_LL (DT : Eqset_dec_pol).
       intros.
       inversion H;intro; try(do 2 LexpSubst);try(constructor);auto;
         inversion H2;try(LexpContr);
-          try(do 2 LexpSubst); try( rewrite <- H4  in H0); intuition.
+          try(do 2 LexpSubst); try( rewrite <- H4  in H0); discriminate.
     Qed.
 
 

--- a/PLL/LL/Focusing/InvLemmas.v
+++ b/PLL/LL/Focusing/InvLemmas.v
@@ -155,7 +155,7 @@ Module InvCopy.
         (* Decide 2 *)
         rewrite union_comm_app in H0.
         simpl_union_context;subst.
-        simpl in H. intuition.
+        discriminate H.
         assert (Hn : S n0 <= S n0) by auto.
         generalize (IH (S n0) Hn);intros.
         destruct H3.
@@ -176,19 +176,19 @@ Module InvCopy.
       ++ (* bot *)
         inversion HD1;subst.
         eexists. eapply tri_dec2 with (F:= ⊥);auto. eapply tri_rel;auto. apply tri_bot. eassumption.
-        simpl in H4. intuition.
+        discriminate H4.
       ++ (* Par *)
         inversion HD1;subst.
         eexists. eapply tri_dec2 with (F:= F0 $ G);auto. eapply tri_rel;auto. apply tri_par. eassumption.
-        simpl in H4. intuition.
+        discriminate H4.
       ++ (* With *)
         inversion HD1;subst.
         eexists. eapply tri_dec2 with (F:= F0 & G);auto. eapply tri_rel;auto. apply tri_with; eassumption.
-        simpl in H4. intuition.
+        discriminate H4.
       ++ (* quest *)
         inversion HD1;subst.
         eexists. eapply tri_dec2 with (F:= ? F0);auto. eapply tri_rel;auto. apply tri_quest. eassumption.
-        simpl in H4. intuition.
+        discriminate H4.
       ++
         (* Store *)
         inversion HD1;subst.
@@ -336,8 +336,7 @@ Module InvCopy.
         destruct H2. simpl in H2.
         eexists.
         eapply tri_rel;auto. eapply tri_bot;auto. eassumption.
-        simpl in H5.
-        intuition.
+        discriminate H5.
 
         apply LPos1 with (L:= [F] ++ M);eauto.
         constructor;auto using PosOrPosAtomAsync.
@@ -360,8 +359,7 @@ Module InvCopy.
         destruct H2. simpl in H2.
         eexists.
         eapply tri_rel;auto. eapply tri_par;auto. eassumption.
-        simpl in H5.
-        intuition.
+        discriminate H5.
         apply LPos1 with (L:= [F] ++ M);eauto.
         constructor;auto using PosOrPosAtomAsync.
 
@@ -397,7 +395,7 @@ Module InvCopy.
         destruct H6. simpl in H6.
         eexists.
         eapply tri_rel;auto. eapply tri_with;auto; eassumption.
-        inversion H5. intuition.
+        discriminate H5.
 
         apply LPos1 with (L:= [F] ++ M);eauto.
         constructor;auto using PosOrPosAtomAsync.
@@ -424,8 +422,7 @@ Module InvCopy.
         eapply tri_rel;auto.  eapply tri_quest;auto.
         rewrite Mequiv. eassumption.
 
-        simpl in H5.
-        intuition.
+        discriminate H5.
         apply LPos1 with (L:= [F] ++ M);eauto.
         constructor;auto using PosOrPosAtomAsync.
 
@@ -447,21 +444,18 @@ Module InvCopy.
         apply eq_then_meq in H.
         contradiction_multiset.
 
-        simpl in H0. 
-        intuition.
+        discriminate H0.
 
       ++ (* 0 *)
         inversion HD1;subst.
-        simpl in H0.
-        intuition.
+        discriminate H0.
 
       ++ (* one *)
         inversion HD1;subst.
         apply eq_then_meq in H2.
         contradiction_multiset.
 
-        simpl in H0.
-        intuition.
+        discriminate H0.
       ++ (* Tensor *)
         inversion HD1;subst.
         assert (Ht : M++[F] =mul= [F] ++ M) by eauto.
@@ -527,8 +521,7 @@ Module InvCopy.
           eassumption.
           eassumption.
 
-        +++ simpl in H0.
-            intuition.
+        +++ discriminate H0.
 
 
       ++ (* Oplus *)
@@ -557,16 +550,14 @@ Module InvCopy.
         destruct H1.
         eexists.
         eapply tri_plus2;eauto.
-        simpl in H0.
-        intuition.
+        discriminate H0.
 
       ++ (* bang *)
         inversion HD1;subst.
         apply eq_then_meq in H.
         contradiction_multiset.
 
-        simpl in H0.
-        intuition.
+        discriminate H0.
   Qed.
 
 
@@ -617,7 +608,7 @@ Module InvPlus.
         apply eq_then_meq in H0. 
         symmetry in H0.
         rewrite union_comm_app in H0.
-        apply resolvers2 in H0. intuition. inversion H1.
+        apply resolvers2 in H0 as [H1 H2]. discriminate H1.
       ++ (* H0 inconsistent *)
         apply eq_then_meq in H0.
         contradiction_multiset.
@@ -922,8 +913,7 @@ Module InvPlus.
         destruct H2. simpl in H2.
         eexists.
         eapply tri_rel;auto. eapply tri_bot;auto. eassumption.
-        simpl in H5.
-        intuition.
+        discriminate H5.
 
         apply LPos1 with (L:= [F] ++ M);eauto.
         constructor;auto using PosOrPosAtomAsync.
@@ -946,8 +936,7 @@ Module InvPlus.
         destruct H2. simpl in H2.
         eexists.
         eapply tri_rel;auto. eapply tri_par;auto. eassumption.
-        simpl in H5.
-        intuition.
+        discriminate H5.
         apply LPos1 with (L:= [F] ++ M);eauto.
         constructor;auto using PosOrPosAtomAsync.
 
@@ -983,7 +972,7 @@ Module InvPlus.
         destruct H6. simpl in H6.
         eexists.
         eapply tri_rel;auto. eapply tri_with;auto; eassumption.
-        inversion H5. intuition.
+        discriminate H5.
 
         apply LPos1 with (L:= [F] ++ M);eauto.
         constructor;auto using PosOrPosAtomAsync.
@@ -1006,8 +995,7 @@ Module InvPlus.
         eexists.
         eapply tri_rel;auto. eapply tri_quest;auto. eassumption.
 
-        simpl in H5.
-        intuition.
+        discriminate H5.
         apply LPos1 with (L:= [F] ++ M);eauto.
         constructor;auto using PosOrPosAtomAsync.
 
@@ -1024,22 +1012,19 @@ Module InvPlus.
         apply EmptyMS in H.
         contradiction.
 
-        simpl in H0.
-        intuition.
+        discriminate H0.
 
 
       ++ (* 0 *)
         inversion HD1;subst.
-        simpl in H0.
-        intuition.
+        discriminate H0.
 
       ++ (* one *)
         inversion HD1;subst.
         apply eq_then_meq in H2.
         contradiction_multiset.
 
-        simpl in H0.
-        intuition.
+        discriminate H0.
       ++ (* Tensor *)
         inversion HD1;subst.
         assert (Ht : M++[F] =mul= [F] ++ M) by solve_permutation.
@@ -1104,8 +1089,7 @@ Module InvPlus.
           eauto.
 
 
-        +++ simpl in H0.
-            intuition.
+        +++ discriminate H0.
 
 
       ++ (* Oplus *)
@@ -1134,18 +1118,16 @@ Module InvPlus.
         destruct H1.
         eexists.
         eapply tri_plus2;eauto.
-        simpl in H0.
-        intuition.
+        discriminate H0.
 
       ++ (* bang *)
         inversion HD1;subst.
         apply eq_then_meq in H.
         contradiction_multiset.
         
-        simpl in H0.
-        intuition.
+        discriminate H0.
   Qed.
-  
+
 
   Theorem InvPlus' : forall n, RInd n.
     intro n.
@@ -1198,7 +1180,7 @@ Module InvTensor.
         apply eq_then_meq in H0. 
         symmetry in H0.
         rewrite union_comm_app in H0.
-        apply resolvers2 in H0; intuition. inversion H1.
+        apply resolvers2 in H0 as [H1 H2]. discriminate H1.
       ++ (* H0 inconsistent *)
         apply eq_then_meq in H0.
         contradiction_multiset. 
@@ -1419,10 +1401,10 @@ Module InvTensor.
       eexists. eapply tri_dec2 with (F:=F0)  ;eauto.
   Qed.
 
-  
 
-  
-  
+
+
+
   Theorem InvTensorAuxNilNilPosPos:
     forall  n n1 n2 B M1 M2 F G ,
       (forall m : nat, m <= n -> RInd m) ->
@@ -1475,8 +1457,8 @@ Module InvTensor.
           by (rewrite H9; solve_permutation).
         eexists. eapply tri_dec1 with (F:=F1);eauto.
         rewrite app_assoc.
-        apply TensorComm ;auto.
-        eapply TriExchange;eauto.
+        apply TensorComm.
+        eapply TriExchange; [ eassumption | reflexivity | ]. solve_permutation.
       ++ (* case F0 <> F , F1 = G *)
         destruct Heq1 as [M1']. destruct H6.
         assert (Hn: S (S (S(n2 + n3))) <= n ) by lia.
@@ -1495,7 +1477,7 @@ Module InvTensor.
         assert(HeqMul: (M1 ++ M2) ++ [F ** F1]  =mul= [F0] ++ (M1' ++ M2  ++ [F ** F1])) by(
                                                                                              rewrite H9; solve_permutation).
         eexists. eapply tri_dec1 with (F:=F0);eauto.
-        
+
       ++ (* case both are different *)
         destruct Heq1 as [M1']. destruct H6.
         destruct Heq2 as [M2']. destruct H10.
@@ -1529,7 +1511,7 @@ Module InvTensor.
       eexists.
       apply TensorComm;auto.
       eapply tri_dec2 with (F:=F1);eauto.
-      eapply TriExchange;eauto.
+      eapply TriExchange; [ eassumption | reflexivity | ]. solve_permutation.
     + (* DEC 1 / DEC 2*)
       assert (Hn: S (S (S(n2 + n3))) <= n ) by lia.
       generalize (IH (S (S (S (n2+ n3)))) Hn) as IH';intros.
@@ -1556,7 +1538,7 @@ Module InvTensor.
       destruct H6.
       eexists.
       rewrite <- app_assoc.
-      eapply tri_dec2 with (F:=F0);eauto.
+      eapply tri_dec2 with (F:=F0); eauto.
   Qed.
 
 
@@ -1678,7 +1660,8 @@ Module InvTensor.
         (* F and G are NotPosOrPosAtom *)
         eexists.
         eapply tri_dec1 with (F := F ** G) ;eauto.
-        eapply tri_tensor with (F:=F) (M:=M2) (N:=M1);auto. solve_permutation.
+        eapply tri_tensor with (F:=F) (M:=M2) (N:=M1).
+        solve_permutation.
         eapply tri_rel; auto using NotPosOrPosAtomRelease;eassumption.
         eapply tri_rel; auto using NotPosOrPosAtomRelease;eassumption.
       ++ (* F is positive and G is Not *)
@@ -1752,7 +1735,7 @@ Module InvTensor.
         eapply LPos1;auto. firstorder.
 
         apply LPos1 with  (L:=[F] ++ M);auto.
-        simpl. intuition. solve_permutation.
+        simpl. solve_permutation.
         constructor;auto.
         apply PosOrPosAtomAsync;auto.
       ++ (* top *)
@@ -1776,8 +1759,7 @@ Module InvTensor.
         destruct H2. simpl in H2.
         eexists.
         eapply tri_rel;auto. eapply tri_bot;auto. eassumption.
-        simpl in H5.
-        intuition.
+        discriminate H5.
 
         apply LPos1 with (L:= [F] ++ M);eauto.
         constructor;auto using PosOrPosAtomAsync.
@@ -1800,8 +1782,7 @@ Module InvTensor.
         destruct H2. simpl in H2.
         eexists.
         eapply tri_rel;auto. eapply tri_par;auto. eassumption.
-        simpl in H5.
-        intuition.
+        discriminate H5.
         apply LPos1 with (L:= [F] ++ M);eauto.
         constructor;auto using PosOrPosAtomAsync.
 
@@ -1838,8 +1819,7 @@ Module InvTensor.
         destruct H6. simpl in H6.
         eexists.
         eapply tri_rel;auto. eapply tri_with;auto; eassumption.
-        simpl in H5.
-        intuition.
+        discriminate H5.
         apply LPos1 with (L:= [F] ++ M);eauto.
         constructor;auto using PosOrPosAtomAsync.
 
@@ -1863,8 +1843,7 @@ Module InvTensor.
         destruct H2. simpl in H2.
         eexists.
         eapply tri_rel;auto. eapply tri_quest;auto. eassumption.
-        simpl in H5.
-        intuition.
+        discriminate H5.
         apply LPos1 with (L:= [F] ++ M);eauto.
         constructor;auto using PosOrPosAtomAsync.
 
@@ -1883,21 +1862,18 @@ Module InvTensor.
 
         apply EmptyMS in H. contradiction.
 
-        simpl in H0. 
-        intuition.
+        discriminate H0.
 
       ++ (* 0 *)
         inversion HD1;subst.
-        simpl in H0.
-        intuition.
+        discriminate H0.
 
       ++ (* one *)
         inversion HD1;subst.
         apply eq_then_meq in H2.
         contradiction_multiset.
 
-        simpl in H0.
-        intuition.
+        discriminate H0.
       ++ (* Tensor *)
         inversion HD1;subst.
 
@@ -1962,8 +1938,7 @@ Module InvTensor.
           eassumption.
           rewrite H.
           solve_permutation.
-        +++ simpl in H0.
-            intuition.
+        +++ discriminate H0.
 
 
       ++ (* Oplus *)
@@ -1986,15 +1961,13 @@ Module InvTensor.
         destruct H1.
         eexists.
         eapply tri_plus2;eauto.
-        simpl in H0.
-        intuition.
+        discriminate H0.
       ++ (* bang *)
         inversion HD1;subst.
         apply eq_then_meq in H.
         contradiction_multiset.
 
-        simpl in H0.
-        intuition.
+        discriminate H0.
   Qed.
 
 

--- a/PLL/LL/Focusing/StructuralRulesTriSystem.v
+++ b/PLL/LL/Focusing/StructuralRulesTriSystem.v
@@ -583,7 +583,7 @@ Proof.
 
       inversion Heqw. subst.
       simpl in H.
-      inversion H; (try now intuition); subst.
+      inversion H; try discriminate; subst.
       apply IH with (m:= L_weight L)in H4 ;auto.
       destruct H4.
 
@@ -605,7 +605,7 @@ Proof.
     ++ (* par *)
       inversion Heqw. subst.
       simpl in H.
-      inversion H;(try now intuition); subst.
+      inversion H; try discriminate; subst.
       apply IH with (L:= l1 :: l2 :: L) (m:= plus (plus (exp_weight l1)  (exp_weight l2)) ( L_weight L))in H4 ; auto.
       destruct H4.
 
@@ -628,7 +628,7 @@ Proof.
     ++ (* with *)
       inversion Heqw. subst.
       simpl in H.
-      inversion H;(try now intuition); subst.
+      inversion H; try discriminate; subst.
       apply IH with (L:= l1 :: L) (m:= plus (exp_weight l1) (L_weight L))in H5 ;auto.
       apply IH with (L:= l2 :: L) (m:= plus (exp_weight l2) (L_weight L))in H7 ;auto.
 
@@ -657,7 +657,7 @@ Proof.
     ++ (* quest *)
       inversion Heqw. subst.
       simpl in H.
-      inversion H;(try now intuition); subst.
+      inversion H; try discriminate; subst.
       apply IH with (m:= L_weight L)in H4 ;auto.
       destruct H4.
 
@@ -969,14 +969,10 @@ Lemma StoreInversionL : forall n B M N L,  n |-F- B; M; UP (N ++ L) -> lexpPos N
     eexists.
     rewrite app_nil_r.
     eauto.
-  + inversion H;subst; try(
-                           inversion H0;
-                           simpl in H1;
-                           intuition).
-    apply H3 in H7.
-    destruct H7. 
+  + inversion H; subst; inversion H0; try discriminate.
+    apply (IHN H2) in H7.
+    destruct H7.
     eexists.
-    assert( M ++ a :: N =mul=  (M ++ [a]) ++ N) by solve_permutation.
-    rewrite H5.
+    assert( M ++ a :: N =mul=  (M ++ [a]) ++ N) as -> by solve_permutation.
     eassumption.
 Qed.

--- a/PLL/LL/llTactics.v
+++ b/PLL/LL/llTactics.v
@@ -497,9 +497,8 @@ Proof.
   rewrite union_comm_app in H. 
   rewrite PM in H.
   rewrite <- union_assoc_app in H.
-  refine (HI _ _ _ _ _ _); 
-    [ | change (0%nat) with (plus 0 0); refine (sig3_cut _ _ _ Hn1 H); auto; try resolve_rewrite];
-    resolve_max.
+  refine (HI _ _ _ _ _ _);
+    [ auto | change (0%nat) with (plus 0 0); refine (sig3_cut _ _ _ Hn1 H); [ auto | auto | ] ].
   app_normalize_aux.
   rewrite <- (my_p _ _ _ M1).
   solve_permutation.


### PR DESCRIPTION
* clean uses of `intuition` tactic
* clean some non-monotone uses of `auto`

These should be backward compatible changes (tested with Coq 8.15.2 and 8.16.1).