### PR TITLE
Adapt to Coq 8.18 and 8.19

### DIFF
--- a/FOLL/LL/CutElimination.v
+++ b/FOLL/LL/CutElimination.v
@@ -127,8 +127,8 @@ Module CElimination (DT : Eqset_dec_pol).
       n |~> 1 ; B ; L -> exists m, m |~> 0 ; B ; L.
   Proof.
     intros.
-    revert dependent B.
-    revert dependent L.
+    generalize dependent B.
+    generalize dependent L.
     induction n using strongind; intros.
     - inversion H.
     - inversion H0; subst. 
@@ -186,9 +186,9 @@ Module CElimination (DT : Eqset_dec_pol).
           eexists; eapply sig3_fx; eauto.
       + (* caso CUT *)
         clear H0. clear H.
-        revert dependent B.
-        revert dependent L.
-        revert dependent n.
+        generalize dependent B.
+        generalize dependent L.
+        generalize dependent n.
         
         dependent induction w using strongind;
           

--- a/FOLL/LL/CutTactics.v
+++ b/FOLL/LL/CutTactics.v
@@ -4,18 +4,16 @@
 Some tactics to automatize part of the proof of cut-elimination 
  *)
 
-(*Add LoadPath "../". *)
 Require Export LL.SequentCalculiBasicTheory.
 Require Export Coq.Init.Logic.
 Require Export Coq.Arith.Wf_nat.
 Require Export Coq.Program.Equality.
-Require Export Coq.Arith.Plus.
 Require Export Lia.
 Export ListNotations.
 Set Implicit Arguments.
 
-#[local] Hint Resolve Nat.le_max_r: core .
-#[local] Hint Resolve Nat.le_max_l: core .
+#[local] Hint Resolve Nat.le_max_r: core.
+#[local] Hint Resolve Nat.le_max_l: core.
 
 Module CTactics (DT : Eqset_dec_pol).
   Module Export Sys :=  SqBasic DT.

--- a/FOLL/LL/SequentCalculiBasicTheory.v
+++ b/FOLL/LL/SequentCalculiBasicTheory.v
@@ -36,8 +36,8 @@ Module SqBasic (DT : Eqset_dec_pol).
   Lemma sig2_der_compat : forall B1 B2 L1 L2 : list Lexp, B1 =mul= B2 -> L1 =mul= L2 -> |-- B1 ; L1 -> |-- B2 ; L2.
   Proof.
     intros B1 B2 L1 L2 PB PL H.
-    revert dependent B2.
-    revert dependent L2.  
+    generalize dependent B2.
+    generalize dependent L2.
     induction H; intros;
       try rewrite PB in *;
       try rewrite PL in *.
@@ -282,11 +282,11 @@ Module SqBasic (DT : Eqset_dec_pol).
       B1 =mul= B2 -> L1 =mul= L2 -> n |~> c ; B1 ; L1 -> n |~> c ; B2 ; L2.
   Proof.
     intros n c B1 B2 L1 L2 PB PL H.
-    revert dependent L1;
-      revert dependent L2;
-      revert dependent B1;
-      revert dependent B2;
-      revert dependent c; 
+    generalize dependent L1;
+      generalize dependent L2;
+      generalize dependent B1;
+      generalize dependent B2;
+      generalize dependent c;
       induction n using strongind; intros.
     - inversion H; subst.
       refine (sig3_init _ (transitivity (symmetry PL) H0)). 
@@ -445,8 +445,8 @@ Module SqBasic (DT : Eqset_dec_pol).
       n |-cc B ; L -> exists c, n |~> c ; B ; L.
   Proof.
     intros.
-    revert dependent B;
-      revert dependent L.
+    generalize dependent B;
+      generalize dependent L.
     induction n using strongind; intros L B Hyp.
     **
       inversion Hyp; subst; eexists.
@@ -536,9 +536,9 @@ Module SqBasic (DT : Eqset_dec_pol).
       n |~> c ; B ; L  -> n |-cc B ; L.
   Proof.
     intros.
-    revert dependent B;
-      revert dependent L;
-      revert dependent c.
+    generalize dependent B;
+      generalize dependent L;
+      generalize dependent c.
     induction n using strongind; intros c L B Hyp.
     **
       inversion Hyp; subst.

--- a/PLL/LL/Focusing/StructuralRulesTriSystem.v
+++ b/PLL/LL/Focusing/StructuralRulesTriSystem.v
@@ -943,7 +943,7 @@ Lemma UpExtension: forall B M L F n, lexpPos (M ++ [F]) -> n |-F- B; M ++ [F] ; 
       assert(exists m0 : nat, m0 <= S n0 /\ m0 |-F- B; M ++ [l]; UP (L ++ [F])).
       apply IH with (m:= L_weight L);eauto using WeightLeq.
       apply LPos1 with (L:= [l] ++ (M ++ [F]));auto.
-      rewrite app_assoc_reverse.
+      rewrite <- app_assoc.
       solve_permutation.
 
       apply lexpPosUnion;auto.

--- a/PLL/LL/MetaTheory/CutElimination.v
+++ b/PLL/LL/MetaTheory/CutElimination.v
@@ -190,8 +190,8 @@ Lemma cut_elimination_base: forall n B L,
     n |~> 1 ; B ; L -> exists m, m |~> 0 ; B ; L.
 Proof.
   intros.
-  revert dependent B.
-  revert dependent L.
+  generalize dependent B.
+  generalize dependent L.
   induction n using strongind; intros.
   - inversion H.
   - inversion H0; subst. 
@@ -250,9 +250,9 @@ Proof.
         refine (sig3_bang _ Ht); auto.
     + (* caso CUT *)
       clear H0. clear H.
-      revert dependent B.
-      revert dependent L.
-      revert dependent n.
+      generalize dependent B.
+      generalize dependent L.
+      generalize dependent n.
 
       dependent induction w using strongind;
 
@@ -820,8 +820,8 @@ Qed.
 Theorem sig3_then_sig2h : forall n B L, n |~> 0 ; B ; L -> exists m, m |-- B ; L.
 Proof.
   intros.
-  revert dependent B.
-  revert dependent L.
+  generalize dependent B.
+  generalize dependent L.
   induction n using strongind; intros.
   inversion H; subst. 
   eexists.

--- a/PLL/LL/SequentCalculi.v
+++ b/PLL/LL/SequentCalculi.v
@@ -109,8 +109,8 @@ where "|-- B ; L" := (sig2 B L).
 Lemma sig2_der_compat : forall B1 B2 L1 L2, B1 =mul= B2 -> L1 =mul= L2 -> |-- B1 ; L1 -> |-- B2 ; L2.
 Proof.
   intros B1 B2 L1 L2 PB PL H.
-  revert dependent B2.
-  revert dependent L2.  
+  generalize dependent B2.
+  generalize dependent L2.
   induction H; intros;
     try rewrite PB in *;
     try rewrite PL in *. assert (L =mul= L). reflexivity. rewrite H in PL. 
@@ -491,11 +491,11 @@ Lemma sig3_der_compat : forall n c (B1 B2 L1 L2: list lexp),
     B1 =mul= B2 -> L1 =mul= L2 -> n |~> c ; B1 ; L1 -> n |~> c ; B2 ; L2.
 Proof.
   intros n c B1 B2 L1 L2 PB PL H.
-  revert dependent L1;
-    revert dependent L2;
-    revert dependent B1;
-    revert dependent B2;
-    revert dependent c; 
+  generalize dependent L1;
+    generalize dependent L2;
+    generalize dependent B1;
+    generalize dependent B2;
+    generalize dependent c;
     induction n using strongind; intros.
   - inversion H; subst.
     refine (sig3_init _ (transitivity (symmetry PL) H0)). 
@@ -667,8 +667,8 @@ Theorem sig2hcc_then_sig3 :  forall B L n,
     n |-cc B ; L -> exists c, n |~> c ; B ; L.
 Proof.
   intros.
-  revert dependent B;
-    revert dependent L.
+  generalize dependent B;
+    generalize dependent L.
   induction n using strongind; intros L B Hyp.
   **
     inversion Hyp; subst; eexists.
@@ -746,9 +746,9 @@ Theorem sig3_then_sig2hcc :  forall B L n c,
     n |~> c ; B ; L  -> n |-cc B ; L.
 Proof.
   intros.
-  revert dependent B;
-    revert dependent L;
-    revert dependent c.
+  generalize dependent B;
+    generalize dependent L;
+    generalize dependent c.
   induction n using strongind; intros c L B Hyp.
   **
     inversion Hyp; subst.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and <a href="mailto:carlos.olarte@gmail.com"> Carlos Olarte</a>
 
 ## Getting Started
 
-The project was tested with Coq 8.14 to 8.18 (thanks to Olivier Laurent!). No extra library is needed for compilation.
+The project was tested with Coq 8.14 to 8.19 (thanks to Olivier Laurent!). No extra library is needed for compilation.
 
 There are two main directories
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and <a href="mailto:carlos.olarte@gmail.com"> Carlos Olarte</a>
 
 ## Getting Started
 
-The project was tested in Coq 8.14 (and 8.17, thanks to Olivier Laurent!). No extra library is needed for compilation.
+The project was tested with Coq 8.14 to 8.18 (thanks to Olivier Laurent!). No extra library is needed for compilation.
 
 There are two main directories
 


### PR DESCRIPTION
- **8.18**
    Remove use of deprecated tactics and statements:
    - `revert dependent`
    - `app_assoc_reverse`

- **8.19**
    Remove reference to `Arith.Plus`.

Proposed version is backward compatible up to Coq 8.14.